### PR TITLE
Add Explore-* view styling for grid like listing

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -390,3 +390,51 @@ div[property="dcterms:description"]:only-of-type {
 
 /* Hide the label in Taxonomy List. See twig template taxonomy-term.html.twig */
 .taxonomy-data .field__label { display: none; }
+
+/* Explore-* Pages Styling */
+[class*="view-explore-"] {
+  margin-bottom: 20px;
+}
+[class*="view-explore-"] h3,
+[class*="view-explore-"] .item-list h3 {
+  font-weight: 700;
+  margin-top: 15px;
+}
+[class*="view-explore-"] .view-content.row {
+  padding: 10px;
+}
+[class*="view-explore-"] .views-summary.views-summary-unformatted,
+[class*="view-explore-"] .item-list li {
+  background: #fff;
+  border: 1px solid #efefef;
+  padding: 5px;
+}
+[class*="view-explore-"] .views-summary.views-summary-unformatted a,
+[class*="view-explore-"] .views-view-grid .views-col a,
+[class*="view-explore-"] .item-list li a {
+  font-weight: bold;
+}
+[class*="view-explore-"] .views-summary.views-summary-unformatted:hover,
+[class*="view-explore-"] .views-summary.views-summary-unformatted:focus,
+[class*="view-explore-"] .item-list li:hover,
+[class*="view-explore-"] .item-list li:focus {
+  background: #efefef;
+  border: 1px solid #efefef;
+  padding: 5px;
+}
+[class*="view-explore-"] .views-view-grid .views-col,
+[class*="view-explore-"] .item-list li {
+  background: #efefef;
+  border: 1px solid #efefef;
+  padding: 10px;
+  /* margin-bottom: 10px; */
+}
+[class*="view-explore-"] .views-view-grid .views-col:hover,
+[class*="view-explore-"] .views-view-grid .views-col:focus,
+[class*="view-explore-"] .item-list li:hover,
+[class*="view-explore-"] .item-list li:focus {
+  background: #e5e5e5;
+  border: 1px solid #efefef;
+  padding: 10px;
+  /* margin-bottom: 10px; */
+}

--- a/york_drupal_theme.theme
+++ b/york_drupal_theme.theme
@@ -88,33 +88,3 @@ function york_drupal_theme_preprocess_taxonomy_term(&$variables) {
     $variables['content'][0] = ['#markup' => $image];
   }
 }
-
-/** 
-* Use common template for Explore A-Z listings 
-*/
-
-// function york_drupal_theme_theme_suggestions_views_view_summary_unformatted_alter(array &$suggestions, array $variables) {
-//   // Get the current view.
-//   $view = $variables['view'];
-
-//   // List the view names you want to target.
-//   $target_views = ['explore_subjects', 'explore_locations'];
-
-//   // Check if the current view is one of the target views.
-//   if (in_array($view->id(), $target_views)) {
-//     $suggestions[] = 'view-views-summary-unformatted--explore-common';
-//   }
-// }
-function york_drupal_theme_preprocess_views_view_summary_unformatted(array &$variables) {
-  // Get the view name.
-  $view_name = $variables['view']->id();
-
-  // Define an array of view names to target.
-  $target_views = ['explore_subjects', 'explore_locations'];
-
-  // Check if the current view is one of the target views.
-  if (in_array($view_name, $target_views)) {
-    // Set the template for the view.
-    $variables['theme_hook_suggestion'] = 'views_view_summary_unformatted__explore_common';
-  }
-}

--- a/york_drupal_theme.theme
+++ b/york_drupal_theme.theme
@@ -88,3 +88,33 @@ function york_drupal_theme_preprocess_taxonomy_term(&$variables) {
     $variables['content'][0] = ['#markup' => $image];
   }
 }
+
+/** 
+* Use common template for Explore A-Z listings 
+*/
+
+// function york_drupal_theme_theme_suggestions_views_view_summary_unformatted_alter(array &$suggestions, array $variables) {
+//   // Get the current view.
+//   $view = $variables['view'];
+
+//   // List the view names you want to target.
+//   $target_views = ['explore_subjects', 'explore_locations'];
+
+//   // Check if the current view is one of the target views.
+//   if (in_array($view->id(), $target_views)) {
+//     $suggestions[] = 'view-views-summary-unformatted--explore-common';
+//   }
+// }
+function york_drupal_theme_preprocess_views_view_summary_unformatted(array &$variables) {
+  // Get the view name.
+  $view_name = $variables['view']->id();
+
+  // Define an array of view names to target.
+  $target_views = ['explore_subjects', 'explore_locations'];
+
+  // Check if the current view is one of the target views.
+  if (in_array($view_name, $target_views)) {
+    // Set the template for the view.
+    $variables['theme_hook_suggestion'] = 'views_view_summary_unformatted__explore_common';
+  }
+}


### PR DESCRIPTION
Hi Nick,

I tried creating templates for the explore view with BS5 markup but it would be 2 files per view. Considering we have 
explore-[collections, types, subjects, locations, creators] would be 10 new files with duplicated code. It would not be DRY Principle. Looking into hooks to have one template apply to multiple views failed (at least for me).

I decided to add css instead with common element being "view-explore-" as prefix for all those views. Therefore I added css for unformatted and grid classes. ~50 lines of styling.

Could you please check that I did not break anything else and what it looks like with more items in the list as I was limited with my localhost:8000 instance. 

Only file modified should be styles.css as I relied on existing drupal grid markup. Requirement is view with "explore_[view]" as machine name with either html list, grid or unformatted in view settings and styles will apply. 

Side note: I had to tweak with background colours as YU Red links on gray does not pass AODA AA or AAA rating but I was able to bring it close enough with lighter background and bolder text to reach 4.1.x contrast vs 4.5+ being passing (which is a guideline, not a rule). 
AAA wants red+white but that is just extreme. 

Cheers

<img width="1258" alt="Screen Shot 2023-10-26 at 4 02 40 PM" src="https://github.com/yorkulibraries/yudl_drupal_theme/assets/4741591/37537a1c-37e4-45b4-b8e8-dc6f33a1f232">
